### PR TITLE
Remove deprecated warnings

### DIFF
--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -185,7 +185,10 @@ resource "google_compute_firewall" "forseti-client-ssh-external" {
   target_service_accounts = [var.client_iam_module.forseti-client-service-account]
   source_ranges           = var.client_ssh_allow_ranges
   priority                = "100"
-  enable_logging          = var.firewall_logging
+
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"
@@ -203,7 +206,10 @@ resource "google_compute_firewall" "forseti-client-ssh-iap" {
   target_service_accounts = [var.client_iam_module.forseti-client-service-account]
   source_ranges           = ["35.235.240.0/20"]
   priority                = "100"
-  enable_logging          = var.firewall_logging
+
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"

--- a/modules/client/main.tf
+++ b/modules/client/main.tf
@@ -157,7 +157,10 @@ resource "google_compute_firewall" "forseti-client-deny-all" {
   target_service_accounts = [var.client_iam_module.forseti-client-service-account]
   source_ranges           = ["0.0.0.0/0"]
   priority                = "200"
-  enable_logging          = var.firewall_logging
+  
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   deny {
     protocol = "icmp"

--- a/modules/client_gcs/main.tf
+++ b/modules/client_gcs/main.tf
@@ -25,14 +25,14 @@ locals {
 # Forseti storage bucket #
 #------------------------#
 resource "google_storage_bucket" "client_config" {
-  count              = var.client_enabled ? 1 : 0
-  name               = local.client_bucket_name
-  location           = var.storage_bucket_location
-  storage_class      = var.storage_bucket_class
-  project            = var.project_id
-  force_destroy      = true
-  bucket_policy_only = true
-  labels             = var.gcs_labels
+  count                       = var.client_enabled ? 1 : 0
+  name                        = local.client_bucket_name
+  location                    = var.storage_bucket_location
+  storage_class               = var.storage_bucket_class
+  project                     = var.project_id
+  force_destroy               = true
+  uniform_bucket_level_access = false
+  labels                      = var.gcs_labels
 
   depends_on = [null_resource.services-dependency]
 }

--- a/modules/real_time_enforcer/main.tf
+++ b/modules/real_time_enforcer/main.tf
@@ -84,11 +84,11 @@ resource "google_organization_iam_member" "enforcer-writer" {
 #---------------------#
 
 resource "google_storage_bucket" "main" {
-  name               = local.enforcer_bucket_name
-  location           = var.storage_bucket_location
-  project            = var.project_id
-  force_destroy      = true
-  bucket_policy_only = true
+  name                        = local.enforcer_bucket_name
+  location                    = var.storage_bucket_location
+  project                     = var.project_id
+  force_destroy               = true
+  uniform_bucket_level_access = false
 }
 
 resource "google_storage_bucket_iam_member" "service_account_read" {

--- a/modules/server/main.tf
+++ b/modules/server/main.tf
@@ -199,7 +199,10 @@ resource "google_compute_firewall" "forseti-server-ssh-external" {
   target_service_accounts = [var.server_iam_module.forseti-server-service-account]
   source_ranges           = var.server_ssh_allow_ranges
   priority                = "100"
-  enable_logging          = var.firewall_logging
+
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"
@@ -217,7 +220,10 @@ resource "google_compute_firewall" "forseti-server-ssh-iap" {
   target_service_accounts = [var.server_iam_module.forseti-server-service-account]
   source_ranges           = ["35.235.240.0/20"]
   priority                = "100"
-  enable_logging          = var.firewall_logging
+
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"
@@ -236,7 +242,10 @@ resource "google_compute_firewall" "forseti-server-allow-grpc" {
   source_ranges           = var.server_grpc_allow_ranges
   source_service_accounts = var.client_iam_module.forseti-client-service-account != null ? [var.client_iam_module.forseti-client-service-account] : null
   priority                = "100"
-  enable_logging          = var.firewall_logging
+
+  log_config {
+    metadata = "EXCLUDE_ALL_METADATA"
+  }
 
   allow {
     protocol = "tcp"

--- a/modules/server_gcs/main.tf
+++ b/modules/server_gcs/main.tf
@@ -28,26 +28,26 @@ locals {
 #------------------------#
 
 resource "google_storage_bucket" "server_config" {
-  name               = local.server_bucket_name
-  location           = var.storage_bucket_location
-  project            = var.project_id
-  storage_class      = var.storage_bucket_class
-  force_destroy      = true
-  bucket_policy_only = true
-  labels             = var.gcs_labels
+  name                        = local.server_bucket_name
+  location                    = var.storage_bucket_location
+  project                     = var.project_id
+  storage_class               = var.storage_bucket_class
+  force_destroy               = true
+  uniform_bucket_level_access = false
+  labels                      = var.gcs_labels
 
   depends_on = [null_resource.services-dependency]
 }
 
 resource "google_storage_bucket" "cai_export" {
-  count              = var.enable_cai_bucket ? 1 : 0
-  name               = local.storage_cai_bucket_name
-  location           = var.bucket_cai_location
-  project            = var.project_id
-  storage_class      = var.storage_bucket_class
-  force_destroy      = true
-  bucket_policy_only = true
-  labels             = var.gcs_labels
+  count                       = var.enable_cai_bucket ? 1 : 0
+  name                        = local.storage_cai_bucket_name
+  location                    = var.bucket_cai_location
+  project                     = var.project_id
+  storage_class               = var.storage_bucket_class
+  force_destroy               = true
+  uniform_bucket_level_access = false
+  labels                      = var.gcs_labels
 
   lifecycle_rule {
     action {


### PR DESCRIPTION
╷
│ Warning: Attribute is deprecated
│ 
│   with module.forseti.module.client.google_compute_firewall.forseti-client-deny-all,
│   on .terraform/modules/forseti/modules/client/main.tf line 160, in resource "google_compute_firewall" "forseti-client-deny-all":
│  160:   enable_logging          = var.firewall_logging
│ 
│ Deprecated in favor of log_config
│ 
│ (and 5 more similar warnings elsewhere)
╵
╷
│ Warning: Deprecated Attribute
│ 
│   with module.forseti.module.client_gcs.google_storage_bucket.client_config,
│   on .terraform/modules/forseti/modules/client_gcs/main.tf line 34, in resource "google_storage_bucket" "client_config":
│   34:   bucket_policy_only = true
│ 
│ Please use the uniform_bucket_level_access as this field has been renamed by Google.
│ 
│ (and 4 more similar warnings elsewhere)
╵